### PR TITLE
Avoid using pointers to interfaces.

### DIFF
--- a/kafka-bridge.go
+++ b/kafka-bridge.go
@@ -14,7 +14,7 @@ import (
 type BridgeApp struct {
 	consumerConfig   *queueConsumer.QueueConfig
 	producerConfig   *queueProducer.MessageProducerConfig
-	producerInstance *queueProducer.MessageProducer
+	producerInstance queueProducer.MessageProducer
 	producerType     string
 }
 
@@ -48,7 +48,7 @@ func newBridgeApp(consumerAddrs string, consumerGroupID string, consumerOffset s
 	bridgeApp := &BridgeApp{
 		consumerConfig:   &consumerConfig,
 		producerConfig:   &producerConfig,
-		producerInstance: &producerInstance,
+		producerInstance: producerInstance,
 		producerType:     producerType,
 	}
 	return bridgeApp

--- a/message_forwarder.go
+++ b/message_forwarder.go
@@ -30,8 +30,7 @@ func (bridge BridgeApp) forwardMsg(msg queueConsumer.Message) {
 		logger.error(fmt.Sprintf("Error parsing message for extracting uuid. Skip forwarding message. Reason: %s", err.Error()))
 	}
 
-	producerInstance := *bridge.producerInstance
-	producerInstance.SendMessage(uuid, queueProducer.Message{Headers: msg.Headers, Body: msg.Body})
+	bridge.producerInstance.SendMessage(uuid, queueProducer.Message{Headers: msg.Headers, Body: msg.Body})
 
 	ctxlogger.info("Message forwarded")
 }


### PR DESCRIPTION
Using a pointer to an interface is golang is almost always wrong or unneccesary.