### PR TITLE
Fix recognition of uppercase uuids.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # Created by .ignore support plugin (hsz.mobi)
 .idea
-*.exe
+coco-kafka-bridge.exe
+coco-kafka-bridge

--- a/message_forwarder.go
+++ b/message_forwarder.go
@@ -7,11 +7,12 @@ import (
 	queueConsumer "github.com/Financial-Times/message-queue-gonsumer/consumer"
 	"github.com/dchest/uniuri"
 	"regexp"
+	"strings"
 )
 
 const tidValidRegexp = "(tid|SYNTHETIC-REQ-MON)[a-zA-Z0-9_-]*$"
-const uuidContextRegexp = "\"uuid\":\"[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}\""
-const uuidValidRegexp = "[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}"
+const uuidValidRegexp = "[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}"
+const uuidContextRegexp = "\"uuid\":\"" + uuidValidRegexp + "\""
 const systemIDValidRegexp = `[a-zA-Z-]*$`
 
 func (bridge BridgeApp) forwardMsg(msg queueConsumer.Message) {
@@ -56,7 +57,7 @@ func extractUUID(msg string) (string, error) {
 	contextRegexp := regexp.MustCompile(uuidContextRegexp)
 	validRegexp := regexp.MustCompile(uuidValidRegexp)
 	uuidContext := contextRegexp.FindString(msg)
-	uuid := validRegexp.FindString(uuidContext)
+	uuid := strings.ToLower(validRegexp.FindString(uuidContext))
 
 	if uuid == "" {
 		return "", fmt.Errorf("UUID is not present")

--- a/message_forwarder_test.go
+++ b/message_forwarder_test.go
@@ -197,6 +197,19 @@ func TestExtractUUID(t *testing.T) {
 			"7543220a-2389-11e5-bd83-71cb60e8f08c",
 			"",
 		},
+		{
+			queueConsumer.Message{
+				Headers: map[string]string{
+					"Message-Id":        "fc429b46-2500-4fe7-88bb-fd507fbaf00c",
+					"Message-Timestamp": "2015-07-06T07:03:09.362Z",
+					"Message-Type":      "cms-content-published",
+					"Content-Type":      "application/json",
+					"X-Request-Id":      "t9happe59y",
+				},
+				Body: `{"uuid":"7543220A-2389-11E5-BD83-71CB60E8F08C","type":"EOM::CompoundStory","value":"test"}`},
+			"7543220a-2389-11e5-bd83-71cb60e8f08c",
+			"",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
for:
Splunk Alert: CMS Kafka Bridge Errors Alert
ERROR   - 2016/04/11 02:34:23 Error parsing message for extracting uuid. Skip forwarding message. Reason: UUID is not present