### PR TITLE
Reconfiguring http clients

### DIFF
--- a/healthchecks.go
+++ b/healthchecks.go
@@ -4,17 +4,22 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	ftHealth "github.com/Financial-Times/go-fthealth"
 	"io"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"time"
+
+	ftHealth "github.com/Financial-Times/go-fthealth"
 )
 
 var httpClient = &http.Client{
 	Timeout: 60 * time.Second,
 	Transport: &http.Transport{
 		MaxIdleConnsPerHost: 100,
+		Dial: (&net.Dialer{
+			KeepAlive: 30 * time.Second,
+		}).Dial,
 	}}
 
 func (bridge BridgeApp) consumeHealthcheck() ftHealth.Check {

--- a/plain_http_producer.go
+++ b/plain_http_producer.go
@@ -3,13 +3,15 @@ package main
 import (
 	"errors"
 	"fmt"
-	queueProducer "github.com/Financial-Times/message-queue-go-producer/producer"
 	"io"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"regexp"
 	"strings"
 	"time"
+
+	queueProducer "github.com/Financial-Times/message-queue-go-producer/producer"
 )
 
 type plainHTTPMessageProducer struct {
@@ -29,6 +31,9 @@ func newPlainHTTPMessageProducer(config queueProducer.MessageProducerConfig) que
 		Timeout: 60 * time.Second,
 		Transport: &http.Transport{
 			MaxIdleConnsPerHost: 100,
+			Dial: (&net.Dialer{
+				KeepAlive: 30 * time.Second,
+			}).Dial,
 		}}}
 	return cmsNotifier
 }


### PR DESCRIPTION
* set timeouts and MaxIdleConnsPerHost for each http client used by the bridge
* this branch was used in the ingester-test cluster while successfully republishing 4.6 million  orgs, so we can safely say the config is ok