### PR TITLE
Add openssl, remove edge repo, simplify update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ RUN apk update \
   && apk add bash \
   && apk add git bzr \
   && apk add go \
-  && apk add openssl \
   && export GOPATH=/gopath \
   && REPO_PATH="github.com/Financial-Times/coco-kafka-bridge" \
   && mkdir -p $GOPATH/src/${REPO_PATH} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,11 @@ FROM alpine
 ADD *.go /kafka-bridge/
 ADD start.sh /
 
-RUN apk add --update bash \
-  && apk --update add git bzr \
-  && echo "http://dl-4.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories \
-  && apk --update add go \
+RUN apk update \ 
+  && apk add bash \
+  && apk add git bzr \
+  && apk add go \
+  && apk add openssl \
   && export GOPATH=/gopath \
   && REPO_PATH="github.com/Financial-Times/coco-kafka-bridge" \
   && mkdir -p $GOPATH/src/${REPO_PATH} \


### PR DESCRIPTION
* ~~since alpine 3.4 we are no longer getting `openssl`, adding it back~~
* ~~missing openssl causes problems when connecting to UCS machines over ssl~~
* update: removing openssl, will change the service files to add the certificates instead
* removed edge repo as we no longer need it - it was there to get go 1.5 when it was not yet available in the stable repo
* simplified the `apk update`, we only need it once