### PR TITLE
Adds the Timestamp to the request header

### DIFF
--- a/plain_http_producer.go
+++ b/plain_http_producer.go
@@ -51,6 +51,11 @@ func (c *plainHTTPMessageProducer) SendMessage(uuid string, message queueProduce
 		req.Header.Add("X-Origin-System-Id", originSystem)
 	}
 	req.Header.Add("X-Request-Id", message.Headers["X-Request-Id"])
+
+	timestamp := message.Headers["Message-Timestamp"]
+	if timestamp != "" {
+		req.Header.Add("Message-Timestamp", timestamp)
+	}
 	if len(c.config.Authorization) > 0 {
 		req.Header.Add("Authorization", c.config.Authorization)
 	}

--- a/plain_http_producer_test.go
+++ b/plain_http_producer_test.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"fmt"
 	queueProducer "github.com/Financial-Times/message-queue-go-producer/producer"
-	"io/ioutil"
 	"github.com/stretchr/testify/assert"
+	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
@@ -41,6 +41,7 @@ func TestSendMessage(t *testing.T) {
 				"X-Origin-System-Id": "methode-web-pub",
 				"X-Request-Id":       "t9happe59y",
 				"Authorization":      "authorizationkey",
+				"Message-Timestamp":  "2015-07-06T07:03:09.362Z",
 			},
 		},
 		{ //authorization missing
@@ -102,6 +103,26 @@ func TestSendMessage(t *testing.T) {
 				Body: `{"uuid":"7543220a-2389-11e5-bd83-71cb60e8f08c","type":"EOM::CompoundStory","value":"test"}`},
 			map[string]string{
 				"X-Origin-System-Id": "",
+				"X-Request-Id":       "t9happe59y",
+				"Authorization":      "",
+			},
+		},
+		{ //Message-Timestamp is missing
+			queueProducer.MessageProducerConfig{
+				Addr: "address",
+			},
+			"",
+			queueProducer.Message{
+				Headers: map[string]string{
+					"Message-Id":       "fc429b46-2500-4fe7-88bb-fd507fbaf00c",
+					"Origin-System-Id": "http://cmdb.ft.com/systems/methode-web-pub",
+					"Message-Type":     "cms-content-published",
+					"Content-Type":     "application/json",
+					"X-Request-Id":     "t9happe59y",
+				},
+				Body: `{"uuid":"7543220a-2389-11e5-bd83-71cb60e8f08c","type":"EOM::CompoundStory","value":"test"}`},
+			map[string]string{
+				"X-Origin-System-Id": "methode-web-pub",
 				"X-Request-Id":       "t9happe59y",
 				"Authorization":      "",
 			},

--- a/plain_http_producer_test.go
+++ b/plain_http_producer_test.go
@@ -64,6 +64,7 @@ func TestSendMessage(t *testing.T) {
 				"X-Origin-System-Id": "methode-web-pub",
 				"X-Request-Id":       "t9happe59y",
 				"Authorization":      "",
+				"Message-Timestamp":  "2015-07-06T07:03:09.362Z",
 			},
 		},
 		{ //host header (queue) is missing
@@ -85,6 +86,7 @@ func TestSendMessage(t *testing.T) {
 				"X-Origin-System-Id": "methode-web-pub",
 				"X-Request-Id":       "t9happe59y",
 				"Authorization":      "",
+				"Message-Timestamp":  "2015-07-06T07:03:09.362Z",
 			},
 		},
 		{ //origin system id is missing
@@ -105,6 +107,7 @@ func TestSendMessage(t *testing.T) {
 				"X-Origin-System-Id": "",
 				"X-Request-Id":       "t9happe59y",
 				"Authorization":      "",
+				"Message-Timestamp":  "2015-07-06T07:03:09.362Z",
 			},
 		},
 		{ //Message-Timestamp is missing
@@ -125,6 +128,7 @@ func TestSendMessage(t *testing.T) {
 				"X-Origin-System-Id": "methode-web-pub",
 				"X-Request-Id":       "t9happe59y",
 				"Authorization":      "",
+				"Message-Timestamp":  "",
 			},
 		},
 	}


### PR DESCRIPTION
This is so that CMSNotifier can chose to use this timestamp instead in the delivery clusters.