### PR TITLE
Fixed orphaned container problem.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM alpine
 
 ADD *.go /kafka-bridge/
-ADD start.sh /
 
 RUN apk update \ 
   && apk add bash \
@@ -19,5 +18,13 @@ RUN apk update \
   && apk del go git bzr \
   && rm -rf $GOPATH /var/cache/apk/* 
 
-ENTRYPOINT [ "/bin/sh", "-c" ]
-CMD [ "/start.sh" ]
+CMD exec ./coco-kafka-bridge -consumer_proxy_addr=$QUEUE_PROXY_ADDRS \
+                             -consumer_group_id=$GROUP_ID \
+                             -consumer_offset=largest \
+                             -consumer_autocommit_enable=$CONSUMER_AUTOCOMMIT_ENABLE \
+                             -consumer_authorization_key="$AUTHORIZATION_KEY" \
+                             -topic=$TOPIC \
+                             -producer_host=$PRODUCER_HOST \
+                             -producer_host_header=$PRODUCER_HOST_HEADER \
+                             -producer_vulcan_auth="$PRODUCER_VULCAN_AUTH" \
+                             -producer_type=$PRODUCER_TYPE

--- a/start.sh
+++ b/start.sh
@@ -1,1 +1,0 @@
-./coco-kafka-bridge -consumer_proxy_addr=$QUEUE_PROXY_ADDRS -consumer_group_id=$GROUP_ID -consumer_offset=largest -consumer_autocommit_enable=$CONSUMER_AUTOCOMMIT_ENABLE -consumer_authorization_key="$AUTHORIZATION_KEY" -topic=$TOPIC -producer_host=$PRODUCER_HOST -producer_host_header=$PRODUCER_HOST_HEADER -producer_vulcan_auth="$PRODUCER_VULCAN_AUTH" -producer_type=$PRODUCER_TYPE


### PR DESCRIPTION
I know the Dockerfile was looking cleaner before, but in that way the app was the 3rd process started in the container, so no way being started with PID 1.
If you have some idea that would keep the .sh file and still run the app on PID 1, please share :smiley: 