### PR TITLE
Transparent handling of X-Origin-System-Id values.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea
 coco-kafka-bridge.exe
 coco-kafka-bridge
+/.project


### PR DESCRIPTION
Now that the CMS notifier handles long and short forms of
X-Origin-System-Id, there is no need for the bridge to manipulate them.
Values should just be passed literally.