### PR TITLE
Added Dummy config map, …

### DIFF
--- a/helm/coco-kafka-bridge/templates/dummy-config-map.yaml
+++ b/helm/coco-kafka-bridge/templates/dummy-config-map.yaml
@@ -5,4 +5,4 @@ apiVersion: v1
 data:
 kind: ConfigMap
 metadata:
-  name: dymmy-bridges-map
+  name: dummy-bridges-map

--- a/helm/coco-kafka-bridge/templates/dummy-config-map.yaml
+++ b/helm/coco-kafka-bridge/templates/dummy-config-map.yaml
@@ -1,0 +1,8 @@
+---
+## Dummy config map, needed if no bridge is configured for an environment,
+## because helm can not install a chart that contains NO k8s manifests
+apiVersion: v1
+data:
+kind: ConfigMap
+metadata:
+  name: dymmy-bridges-map


### PR DESCRIPTION
Needed if no bridge is configured for an environment, because helm can not install a chart that contains NO k8s manifests