### PR TITLE
Automatically recreating RUNBOOK.md without relationships [Skip CI]

### DIFF
--- a/runbooks/runbook.md
+++ b/runbooks/runbook.md
@@ -1,3 +1,7 @@
+<!--
+    Written in the format prescribed by https://github.com/Financial-Times/runbook.md.
+    Any future edits should abide by this format.
+-->
 # UPP - Kafka Bridge
 
 The purpose of the Kafka Bridge is to replicate (bridge) messages from one UPP Kubernetes cluster to another.
@@ -8,7 +12,7 @@ kafka-bridge
 
 ## Primary URL
 
-<https://upp-prod-delivery-glb.upp.ft.com/__cms-kafka-bridge-pub-prod-eu/>
+https://upp-prod-delivery-glb.upp.ft.com/__cms-kafka-bridge-pub-prod-eu/
 
 ## Service Tier
 
@@ -17,22 +21,6 @@ Platinum
 ## Lifecycle Stage
 
 Production
-
-## Delivered By
-
-content
-
-## Supported By
-
-content
-
-## Known About By
-
-- mihail.mihaylov
-- hristo.georgiev
-- elitsa.pavlova
-- kalin.arsov
-- boyko.boykov
 
 ## Host Platform
 
@@ -53,10 +41,19 @@ No
 
 No
 
-## Dependencies
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Download Personal Data
+Choose Yes or No
 
-- kafka-proxy
-- up-cms-notifier
+...or delete this placeholder if not applicable to this system
+-->
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Contact Individuals
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Failover Architecture Type
 
@@ -97,6 +94,14 @@ Failover is recommended during release in order to avoid publishing delays and m
 The failover guide for the Delivery cluster is located here:
 <https://github.com/Financial-Times/upp-docs/tree/master/failover-guides/delivery-cluster>
 
+<!-- Placeholder - remove HTML comment markers to activate
+## Heroku Pipeline Name
+Enter descriptive text satisfying the following:
+This is the name of the Heroku pipeline for this system. If you don't have a pipeline, this is the name of the app in Heroku. A pipeline is a group of Heroku apps that share the same codebase where each app in a pipeline represents the different stages in a continuous delivery workflow, i.e. staging, production.
+
+...or delete this placeholder if not applicable to this system
+-->
+
 ## Key Management Process Type
 
 Manual
@@ -108,27 +113,30 @@ To access the service clients need to provide basic auth credentials. To rotate 
 ## Monitoring
 
 Delivery EU cluster Kafka bridges:
-- Publishing EU Content Bridge <https://upp-prod-delivery-eu.upp.ft.com/__health/__pods-health?service-name=cms-kafka-bridge-pub-prod-eu>
-- Publishing US Content Bridge <https://upp-prod-delivery-eu.upp.ft.com/__health/__pods-health?service-name=cms-kafka-bridge-pub-prod-us>
-- Publishing EU Metadata Bridge <https://upp-prod-delivery-eu.upp.ft.com/__health/__pods-health?service-name=cms-metadata-kafka-bridge-pub-prod-eu>
-- Publishing US Metadata Bridge <https://upp-prod-delivery-eu.upp.ft.com/__health/__pods-health?service-name=cms-metadata-kafka-bridge-pub-prod-us>
+
+*   Publishing EU Content Bridge <https://upp-prod-delivery-eu.upp.ft.com/__health/__pods-health?service-name=cms-kafka-bridge-pub-prod-eu>
+*   Publishing US Content Bridge <https://upp-prod-delivery-eu.upp.ft.com/__health/__pods-health?service-name=cms-kafka-bridge-pub-prod-us>
+*   Publishing EU Metadata Bridge <https://upp-prod-delivery-eu.upp.ft.com/__health/__pods-health?service-name=cms-metadata-kafka-bridge-pub-prod-eu>
+*   Publishing US Metadata Bridge <https://upp-prod-delivery-eu.upp.ft.com/__health/__pods-health?service-name=cms-metadata-kafka-bridge-pub-prod-us>
 
 Delivery US cluster Kafka bridges:
-- Publishing EU Content Bridge <https://upp-prod-delivery-us.upp.ft.com/__health/__pods-health?service-name=cms-kafka-bridge-pub-prod-eu>
-- Publishing US Content Bridge <https://upp-prod-delivery-us.upp.ft.com/__health/__pods-health?service-name=cms-kafka-bridge-pub-prod-us>
-- Publishing EU Metadata Bridge <https://upp-prod-delivery-us.upp.ft.com/__health/__pods-health?service-name=cms-metadata-kafka-bridge-pub-prod-eu>
-- Publishing US Metadata Bridge <https://upp-prod-delivery-us.upp.ft.com/__health/__pods-health?service-name=cms-metadata-kafka-bridge-pub-prod-us>
+
+*   Publishing EU Content Bridge <https://upp-prod-delivery-us.upp.ft.com/__health/__pods-health?service-name=cms-kafka-bridge-pub-prod-eu>
+*   Publishing US Content Bridge <https://upp-prod-delivery-us.upp.ft.com/__health/__pods-health?service-name=cms-kafka-bridge-pub-prod-us>
+*   Publishing EU Metadata Bridge <https://upp-prod-delivery-us.upp.ft.com/__health/__pods-health?service-name=cms-metadata-kafka-bridge-pub-prod-eu>
+*   Publishing US Metadata Bridge <https://upp-prod-delivery-us.upp.ft.com/__health/__pods-health?service-name=cms-metadata-kafka-bridge-pub-prod-us>
 
 Splunk alert:
-- UPP Prod - Kafka Delivery Bridges not forwarding messages: <https://financialtimes.splunkcloud.com/en-US/manager/search/saved/searches?app=&count=10&offset=0&itemType=&owner=&search=UPP%20Prod%20-%20Kafka%20Delivery%20Bridges%20not%20forwarding%20messages>
+
+*   UPP Prod - Kafka Delivery Bridges not forwarding messages: <https://financialtimes.splunkcloud.com/en-US/manager/search/saved/searches?app=&count=10&offset=0&itemType=&owner=&search=UPP%20Prod%20-%20Kafka%20Delivery%20Bridges%20not%20forwarding%20messages>
 
 ## First Line Troubleshooting
 
-https://github.com/Financial-Times/upp-docs/tree/master/guides/ops/first-line-troubleshooting
+<https://github.com/Financial-Times/upp-docs/tree/master/guides/ops/first-line-troubleshooting>
 
 ## Second Line Troubleshooting
 
-- Check that the Kafka REST proxy and CMS Notifier services are healthy.
-- Check that Kafka and Zookeeper are healthy.
-- Check the logs for successful processing of messages or errors.
-- Restart the service.
+*   Check that the Kafka REST proxy and CMS Notifier services are healthy.
+*   Check that Kafka and Zookeeper are healthy.
+*   Check the logs for successful processing of messages or errors.
+*   Restart the service.


### PR DESCRIPTION

## What
 - The [RUNBOOK.md](https://github.com/Financial-Times/coco-kafka-bridge/blob/runbook-no-relationships-2021-03-19/runbooks/runbook.md) file has been automatically regenerated from the Biz Ops data for the **kafka-bridge** system.
 - All the relationships/dependencies have been excluded from RUNBOOK.md but are still in the **kafka-bridge** system in [Biz Ops](https://biz-ops.in.ft.com/System/kafka-bridge).
 - Please continue to manage those relationships/dependencies manually or via the Biz Ops API.

## Why
 - Support for relationships/dependencies within RUNBOOK.md is being removed to avoid the side effects [identified in this proposal](https://docs.google.com/document/d/1njFceyb49TeaIR53Y9r62CenTzdey1fyeJkUvxd9SQQ)
 - This is a prerequisite to the improved ownership/support model [defined in this proposal](https://docs.google.com/document/d/1vTRe7S5dUqIMAoWyqD2pMEkg_5998NCEeFwsxT_k9pw).

## Next Steps
 - Please check and merge this PR.
 - You should only see the removal of the **Delivered By**, **Supported By**, **Technical Owner**, **Known About By**, **Stakeholders**, **Dependencies** and **Healthcheck** sections. Please contact [#reliability-eng](https://financialtimes.slack.com/archives/C07B3043U) if there are other differences as your current runbook.md file may be inconsistent with Biz Ops.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are unlocking all the relationships/dependencies to re-enable manual/API updates.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are adjusting the rules to allow these simpler RUNBOOK.md files to pass validation.
