### PR TITLE
Removing PostConceptAnnotations bridge.

### DIFF
--- a/helm/coco-kafka-bridge/app-configs/kafka-bridge_eks_delivery_dev.yaml
+++ b/helm/coco-kafka-bridge/app-configs/kafka-bridge_eks_delivery_dev.yaml
@@ -34,13 +34,6 @@ bridges:
     producer: "http://kafka-rest-proxy-msk:8080"
     type: "proxy"
     replicas: 1
-  - name: kafka-to-msk-post-concept-annotations-bridge
-    sourceKafkaProxyUrl: "http://kafka-rest-proxy:8080"
-    groupIdPrefix: kafka-msk-PostConceptAnnotations-bridge
-    topic: PostConceptAnnotations
-    producer: "http://kafka-rest-proxy-msk:8080"
-    type: "proxy"
-    replicas: 1
   - name: kafka-to-msk-concept-annotations-bridge
     sourceKafkaProxyUrl: "http://kafka-rest-proxy:8080"
     groupIdPrefix: kafka-msk-ConceptAnnotations-bridge

--- a/helm/coco-kafka-bridge/app-configs/kafka-bridge_eks_delivery_prod_eu.yaml
+++ b/helm/coco-kafka-bridge/app-configs/kafka-bridge_eks_delivery_prod_eu.yaml
@@ -57,13 +57,6 @@ bridges:
   producer: "http://kafka-rest-proxy-msk:8080"
   type: "proxy"
   replicas: 1
-- name: kafka-to-msk-post-concept-annotations-bridge
-  sourceKafkaProxyUrl: "http://kafka-rest-proxy:8080"
-  groupIdPrefix: kafka-msk-PostConceptAnnotations-bridge
-  topic: PostConceptAnnotations
-  producer: "http://kafka-rest-proxy-msk:8080"
-  type: "proxy"
-  replicas: 1
 - name: kafka-to-msk-concept-annotations-bridge
   sourceKafkaProxyUrl: "http://kafka-rest-proxy:8080"
   groupIdPrefix: kafka-msk-ConceptAnnotations-bridge

--- a/helm/coco-kafka-bridge/app-configs/kafka-bridge_eks_delivery_prod_us.yaml
+++ b/helm/coco-kafka-bridge/app-configs/kafka-bridge_eks_delivery_prod_us.yaml
@@ -57,13 +57,6 @@ bridges:
   producer: "http://kafka-rest-proxy-msk:8080"
   type: "proxy"
   replicas: 1
-- name: kafka-to-msk-post-concept-annotations-bridge
-  sourceKafkaProxyUrl: "http://kafka-rest-proxy:8080"
-  groupIdPrefix: kafka-msk-PostConceptAnnotations-bridge
-  topic: PostConceptAnnotations
-  producer: "http://kafka-rest-proxy-msk:8080"
-  type: "proxy"
-  replicas: 1
 - name: kafka-to-msk-concept-annotations-bridge
   sourceKafkaProxyUrl: "http://kafka-rest-proxy:8080"
   groupIdPrefix: kafka-msk-ConceptAnnotations-bridge

--- a/helm/coco-kafka-bridge/app-configs/kafka-bridge_eks_delivery_staging_eu.yaml
+++ b/helm/coco-kafka-bridge/app-configs/kafka-bridge_eks_delivery_staging_eu.yaml
@@ -57,13 +57,6 @@ bridges:
   producer: "http://kafka-rest-proxy-msk:8080"
   type: "proxy"
   replicas: 1
-- name: kafka-to-msk-post-concept-annotations-bridge
-  sourceKafkaProxyUrl: "http://kafka-rest-proxy:8080"
-  groupIdPrefix: kafka-msk-PostConceptAnnotations-bridge
-  topic: PostConceptAnnotations
-  producer: "http://kafka-rest-proxy-msk:8080"
-  type: "proxy"
-  replicas: 1
 - name: kafka-to-msk-concept-annotations-bridge
   sourceKafkaProxyUrl: "http://kafka-rest-proxy:8080"
   groupIdPrefix: kafka-msk-ConceptAnnotations-bridge

--- a/helm/coco-kafka-bridge/app-configs/kafka-bridge_eks_delivery_staging_us.yaml
+++ b/helm/coco-kafka-bridge/app-configs/kafka-bridge_eks_delivery_staging_us.yaml
@@ -57,13 +57,6 @@ bridges:
   producer: "http://kafka-rest-proxy-msk:8080"
   type: "proxy"
   replicas: 1
-- name: kafka-to-msk-post-concept-annotations-bridge
-  sourceKafkaProxyUrl: "http://kafka-rest-proxy:8080"
-  groupIdPrefix: kafka-msk-PostConceptAnnotations-bridge
-  topic: PostConceptAnnotations
-  producer: "http://kafka-rest-proxy-msk:8080"
-  type: "proxy"
-  replicas: 1
 - name: kafka-to-msk-concept-annotations-bridge
   sourceKafkaProxyUrl: "http://kafka-rest-proxy:8080"
   groupIdPrefix: kafka-msk-ConceptAnnotations-bridge


### PR DESCRIPTION
# Description

## What

Part of MSK migration. All producers and consumers of `PostConceptAnnotations` have been migrated, so we do not need this bridge

## Why

https://financialtimes.atlassian.net/browse/UPPSF-3289

## Anything, in particular, you'd like to highlight to reviewers

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)

___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
